### PR TITLE
Ensure using the full path of provided JDK

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 junitVersion=4.12
-artifactVersion=1.0.2
+artifactVersion=1.0.3

--- a/launcher-scripts/Mac-launcher.sh
+++ b/launcher-scripts/Mac-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 OLD_JAVA_HOME=$JAVA_HOME
-SCRIPT_DIRECTORY=${0:h}
+SCRIPT_DIRECTORY=${0:A:h}
 export JAVA_HOME=$SCRIPT_DIRECTORY/jdk8u212-b03-jre/Contents/Home
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME


### PR DESCRIPTION
We need add a 'A' modifier between '0' and 'h' so that we can get the full path of the provided JRE.
According to the man page : the A modifier turns a file name into an absolute path as the `a’ modifier does, and then pass the result through the real-path(3) library function to resolve symbolic links.

All 4 scenarios were Tested by Carl:   
Command line with the script;
Command line with symlink;
doubleclick with script;
doublclick with alias.