### PR TITLE
#35 Upgrade jackson-databind to 2.10.2 and bump version to alpha

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.26'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
     implementation 'org.jasypt:jasypt:1.9.2'
     runtimeOnly 'org.slf4j:slf4j-simple:1.6.4'
     testImplementation "junit:junit:$junitVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 junitVersion=4.12
-artifactVersion=1.0.3
+artifactVersion=1.0.4-Alpha

--- a/src/main/java/org/apereo/openequella/adminconsole/service/JsonService.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/service/JsonService.java
@@ -24,11 +24,11 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonService {
 	
-	private static final JsonMapper jsonMapper = new JsonMapper();
+	private static final ObjectMapper jsonMapper = new ObjectMapper();
 
 	public static <T> T readFile(File file, Class<T> type){
 		try (final InputStream fis = new FileInputStream(file)) {

--- a/src/main/java/org/apereo/openequella/adminconsole/service/JsonService.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/service/JsonService.java
@@ -24,12 +24,12 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class JsonService {
 	
-	private static final ObjectMapper jsonMapper = new ObjectMapper();
-	
+	private static final JsonMapper jsonMapper = new JsonMapper();
+
 	public static <T> T readFile(File file, Class<T> type){
 		try (final InputStream fis = new FileInputStream(file)) {
 			final T obj = jsonMapper.readValue(fis, type);


### PR DESCRIPTION
#35 

Based on the changelog, I switched `ObjectMapper` to `JsonMapper`.  Didn't see anything else that would to be modified.  Looks like `databind` is only used in a single class in the admin console launcher, and it's a fairly simple one at that.