### PR TITLE
#37 - upgrade jdk/jre to 8u242-b08

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,20 +59,20 @@ final launcherScripts = [
 class JreProperties {
     String hash
     String fileName
-    String getDownloadUrl() {"https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/${fileName}"}
+    String getDownloadUrl() {"https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/${fileName}"}
     File getJre() {new File("build/jre-downloads/${fileName}")}
 }
 
 final jreProperties = [
     windows: new JreProperties(
-            hash: 'c09bab89cd82483c371597c5c364094a145c1fbba43a1d3d7c3e350b89dedc89',
-            fileName: 'OpenJDK8U-jre_x64_windows_hotspot_8u212b03.zip'),
+            hash: 'b00c361e6ce022c6dc63b7c747cfdd9d28c17943e50bc1855adf36854ce46898',
+            fileName: 'OpenJDK8U-jre_x64_windows_hotspot_8u242b08.zip'),
     linux: new JreProperties(
-            hash: '74daf0b77a7fd679cbb3a6228e0efa8c4a90b7664aa057f211e34bbfb38640fb',
-            fileName: 'OpenJDK8U-jre_x64_linux_hotspot_8u212b03.tar.gz'),
+            hash: '5edfaefdbb0469d8b24d61c8aef80c076611053b1738029c0232b9a632fe2708',
+            fileName: 'OpenJDK8U-jre_x64_linux_hotspot_8u242b08.tar.gz'),
     mac: new JreProperties(
-            hash: '80855320c42a3b06617c6e466c64df67731542a805972185b075ca6cb1222c7f',
-            fileName: 'OpenJDK8U-jre_x64_mac_hotspot_8u212b03.tar.gz')
+            hash: 'fae3777e3441dc7384c339a9054aa7efc40cd2c501625a535c2d4648367ccca3',
+            fileName: 'OpenJDK8U-jre_x64_mac_hotspot_8u242b08.tar.gz')
 ]
 
 task copyDependencies(type: Copy, description: 'Copy dependencies to /build/libs') {

--- a/launcher-scripts/Linux-launcher.sh
+++ b/launcher-scripts/Linux-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=`readlink -f "$(dirname "$0")"`
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk8u212-b03-jre
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk8u242-b08-jre
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Mac-launcher.sh
+++ b/launcher-scripts/Mac-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=${0:A:h}
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk8u212-b03-jre/Contents/Home
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk8u242-b08-jre/Contents/Home
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,7 +1,7 @@
 @echo off
 set OLD_JAVA_HOME=%JAVA_HOME%
 set BAT_DIRECTORY=%~dp0
-set JAVA_HOME=%BAT_DIRECTORY%jdk8u212-b03-jre
+set JAVA_HOME=%BAT_DIRECTORY%jdk8u242-b08-jre
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
 set JAVA_HOME=%OLD_JAVA_HOME%
 set OLD_JAVA_HOME=


### PR DESCRIPTION
#37

Best I could find of the change logs are below.  Nothing jumped out to warrant a code change besides the version bump.

https://adoptopenjdk.net/release_notes.html (which unfortunately doesn't include 242)

and specifically for 8u242:  http://mail.openjdk.java.net/pipermail/jdk8u-dev/2020-January/010979.html