### PR TITLE
Add to README.md to detail how to add Root CA Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,35 @@ These packages will be produced as part of the standard build task.
  ```
   -$ ./gradlew build
  ```
+
+## Adding Root CA Certificates
+Self signing certificates can be very useful for local testing & development with SSL enabled. 
+If openEQUELLA is configured to use SSL with such a certificate, then the admin-console-package will fail to log in to the institution because of this error: 
+
+```
+Caused by: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: 
+PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: 
+unable to find valid certification path to requested target
+```
+
+This is because the Java Keystore used by the admin console package does not recognize the Root CA certificate used to sign openEQUELLA's SSL certificate.
+The admin console package uses its own copy of the JRE, in the `jdk8u242-b08-jre` folder. 
+The keystore we need to update is within this folder, at the path `jdk8u242-b08-jre/lib/security/cacerts`.
+
+Java comes with a command line tool which you can use for updating these keystores, called `keytool`. This should work in Mac, Linux and Windows.
+
+You will need a copy of the Root CA certificate used to sign your SSL certificate saved as a .pem file for the following command's `-file` argument.
+
+`-alias` can be whatever you wish to call this key store entry.
+
+`-storepass` must be `changeit` - unless you have specifically changed this password first, 
+in which case you should use whatever it was set to.
+```
+keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk8u242-b08-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
+```
+
+The command will display the certificate and prompt the user to `Trust this certificate? [no]:`. Type `yes` and hit Enter.
+If successful, the response will be:
+`Certificate was added to keystore`.
+
+Now close and reopen the admin-console-package and attempt to log into your openEQUELLA's admin console. The error should be gone and login should be successful.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The keystore we need to update is within this folder, at the path `jdk8u242-b08-
 The bundled JRE comes with a command line tool which you can use for updating these keystores, called `keytool`. 
 This should work in Mac, Linux and Windows. It is stored in `jdk8u242-b08-jre/bin`.
 
-#### NOTE:
+**NOTE:**
 
 If Java is installed on your system it will have its own version of `keystore`. 
 You should use the one within the admin-console-package's bundled JRE rather than your system Java version, to ensure compatibility.
@@ -78,6 +78,6 @@ keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk8u242-b08
 The command will display the certificate and prompt the user to `Trust this certificate? [no]:`. Type `yes` and hit Enter.
 If successful, the response will be:
 
-`Certificate was added to keystore`.
+    Certificate was added to keystore.
 
 Now close and reopen the admin-console-package and attempt to log into your openEQUELLA's admin console. The error should be gone and login should be successful.

--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ You will need a copy of the Root CA certificate used to sign your SSL certificat
 
 `-storepass` must be `changeit` - unless you have specifically changed this password first, 
 in which case you should use whatever it was set to.
+
 ```
 keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk8u242-b08-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
 ```
 
 The command will display the certificate and prompt the user to `Trust this certificate? [no]:`. Type `yes` and hit Enter.
 If successful, the response will be:
+
 `Certificate was added to keystore`.
 
 Now close and reopen the admin-console-package and attempt to log into your openEQUELLA's admin console. The error should be gone and login should be successful.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ These packages will be produced as part of the standard build task.
  ```
 
 ## Adding Root CA Certificates
-Self signing certificates can be very useful for local testing & development with SSL enabled. 
-If openEQUELLA is configured to use SSL with such a certificate, then the admin-console-package will fail to log in to the institution because of this error: 
+If openEQUELLA is configured to use SSL with a certificate that is not recognized by Java, (such as with a self-signed certificate, an internal CA, smaller/lesser known third party CAs)
+then the admin-console-package will fail to log in to the institution because of this error displayed in the terminal window: 
 
 ```
 Caused by: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: 
@@ -52,10 +52,17 @@ unable to find valid certification path to requested target
 ```
 
 This is because the Java Keystore used by the admin console package does not recognize the Root CA certificate used to sign openEQUELLA's SSL certificate.
-The admin console package uses its own copy of the JRE, in the `jdk8u242-b08-jre` folder. 
+
+The admin-console-package uses its own copy of the JRE, in the `jdk8u242-b08-jre` folder. 
 The keystore we need to update is within this folder, at the path `jdk8u242-b08-jre/lib/security/cacerts`.
 
-Java comes with a command line tool which you can use for updating these keystores, called `keytool`. This should work in Mac, Linux and Windows.
+The bundled JRE comes with a command line tool which you can use for updating these keystores, called `keytool`. 
+This should work in Mac, Linux and Windows. It is stored in `jdk8u242-b08-jre/bin`.
+
+#### NOTE:
+
+If Java is installed on your system it will have its own version of `keystore`. 
+You should use the one within the admin-console-package's bundled JRE rather than your system Java version, to ensure compatibility.
 
 You will need a copy of the Root CA certificate used to sign your SSL certificate saved as a .pem file for the following command's `-file` argument.
 


### PR DESCRIPTION
#34 
A common problem that pops up with the admin console package is Root CA certificates missing from the bundled JRE - generally for self-signed certificates.

Added a simple tutorial on how to get this working using `keytool`.