### PR TITLE
Escape the set commands in Windows batch file

### DIFF
--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,7 +1,7 @@
 @echo off
-set "OLD_JAVA_HOME=%JAVA_HOME%"
+set OLD_JAVA_HOME="%JAVA_HOME%"
 set "BAT_DIRECTORY=%~dp0"
 set "JAVA_HOME=%BAT_DIRECTORY%jdk8u242-b08-jre"
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
-set "JAVA_HOME=%OLD_JAVA_HOME%"
-set "OLD_JAVA_HOME="
+set JAVA_HOME="%OLD_JAVA_HOME%"
+set OLD_JAVA_HOME=""

--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,9 +1,7 @@
 @echo off
-setlocal EnableDelayedExpansion
 set "OLD_JAVA_HOME=%JAVA_HOME%"
 set "BAT_DIRECTORY=%~dp0"
 set "JAVA_HOME=%BAT_DIRECTORY%jdk8u242-b08-jre"
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
 set "JAVA_HOME=%OLD_JAVA_HOME%"
 set "OLD_JAVA_HOME="
-endlocal

--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,7 +1,9 @@
 @echo off
+setlocal EnableDelayedExpansion
 set "OLD_JAVA_HOME=%JAVA_HOME%"
 set "BAT_DIRECTORY=%~dp0"
 set "JAVA_HOME=%BAT_DIRECTORY%jdk8u242-b08-jre"
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
 set "JAVA_HOME=%OLD_JAVA_HOME%"
 set "OLD_JAVA_HOME="
+endlocal

--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,7 +1,7 @@
 @echo off
-set OLD_JAVA_HOME=%JAVA_HOME%
-set BAT_DIRECTORY=%~dp0
-set JAVA_HOME=%BAT_DIRECTORY%jdk8u242-b08-jre
+set "OLD_JAVA_HOME=%JAVA_HOME%"
+set "BAT_DIRECTORY=%~dp0"
+set "JAVA_HOME=%BAT_DIRECTORY%jdk8u242-b08-jre"
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
-set JAVA_HOME=%OLD_JAVA_HOME%
-set OLD_JAVA_HOME=
+set "JAVA_HOME=%OLD_JAVA_HOME%"
+set "OLD_JAVA_HOME="


### PR DESCRIPTION
This is intended to address #39.

So in Windows, the Admin Console Package will not work with certain characters in the file path. This is because the set commands in the batch file were not escaped, so when special characters come up they are evaluated during the set command as parts of the command rather than a string value.
This can be avoided by surrounding the content of the set commands with double quotes, to escape the strings and also enabling delayed expansion. 
