### PR TITLE
feat: update the bundled JRE to v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ unable to find valid certification path to requested target
 
 This is because the Java Keystore used by the admin console package does not recognize the Root CA certificate used to sign openEQUELLA's SSL certificate.
 
-The admin-console-package uses its own copy of the JRE, in the `jdk8u242-b08-jre` folder. 
-The keystore we need to update is within this folder, at the path `jdk8u242-b08-jre/lib/security/cacerts`.
+The admin-console-package uses its own copy of the JRE, in the `jdk-11.0.18+10-jre` folder. 
+The keystore we need to update is within this folder, at the path `jdk-11.0.18+10-jre/lib/security/cacerts`.
 
 The bundled JRE comes with a command line tool which you can use for updating these keystores, called `keytool`. 
-This should work in Mac, Linux and Windows. It is stored in `jdk8u242-b08-jre/bin`.
+This should work in Mac, Linux and Windows. It is stored in `jdk-11.0.18+10-jre/bin`.
 
 **NOTE:**
 
@@ -72,7 +72,7 @@ You will need a copy of the Root CA certificate used to sign your SSL certificat
 in which case you should use whatever it was set to.
 
 ```
-keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk8u242-b08-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
+keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk-11.0.18+10-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
 ```
 
 The command will display the certificate and prompt the user to `Trust this certificate? [no]:`. Type `yes` and hit Enter.

--- a/build.gradle
+++ b/build.gradle
@@ -54,20 +54,20 @@ final launcherScripts = [
 class JreProperties {
     String hash
     String fileName
-    String getDownloadUrl() {"https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/${fileName}"}
+    String getDownloadUrl() {"https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.18%2B10/${fileName}"}
     File getJre() {new File("build/jre-downloads/${fileName}")}
 }
 
 final jreProperties = [
     windows: new JreProperties(
-            hash: 'b00c361e6ce022c6dc63b7c747cfdd9d28c17943e50bc1855adf36854ce46898',
-            fileName: 'OpenJDK8U-jre_x64_windows_hotspot_8u242b08.zip'),
+            hash: 'dea0fe7fd5fc52cf5e1d3db08846b6a26238cfcc36d5527d1da6e3cb059071b3',
+            fileName: 'OpenJDK11U-jre_x64_windows_hotspot_11.0.18_10.zip'),
     linux: new JreProperties(
-            hash: '5edfaefdbb0469d8b24d61c8aef80c076611053b1738029c0232b9a632fe2708',
-            fileName: 'OpenJDK8U-jre_x64_linux_hotspot_8u242b08.tar.gz'),
+            hash: '0e7b196ef8603ac3d38caaf7768b7b0a3c613d60e15a6511bcfb2c894b609e99',
+            fileName: 'OpenJDK11U-jre_x64_linux_hotspot_11.0.18_10.tar.gz'),
     mac: new JreProperties(
-            hash: 'fae3777e3441dc7384c339a9054aa7efc40cd2c501625a535c2d4648367ccca3',
-            fileName: 'OpenJDK8U-jre_x64_mac_hotspot_8u242b08.tar.gz')
+            hash: '7c73b1a731fc840f2ecb5633906d687bfee4346a8191d3cb1c4370168b16351f',
+            fileName: 'OpenJDK11U-jre_x64_mac_hotspot_11.0.18_10.tar.gz')
 ]
 
 task copyDependencies(type: Copy, description: 'Copy dependencies to /build/libs') {
@@ -130,16 +130,9 @@ task unzipJre(description: 'Unzip a JRE when the extract directory is missing', 
             !new File(jreExtractDir(sys)).exists()
         }.each {String sys, JreProperties props ->
             println "Unzip JRE for ${sys}"
-            if (props.jre.name.endsWith('zip')) {
-                copy {
-                    from zipTree(props.jre)
-                    into file(jreExtractDir(sys))
-                }
-            } else {
-                copy {
-                    from tarTree(resources.gzip(props.jre))
-                    into file(jreExtractDir(sys))
-                }
+            copy {
+                from props.jre.name.endsWith('zip') ? zipTree(props.jre) : tarTree(resources.gzip(props.jre))
+                into file(jreExtractDir(sys))
             }
         }
     }

--- a/launcher-scripts/Linux-launcher.sh
+++ b/launcher-scripts/Linux-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=`readlink -f "$(dirname "$0")"`
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk8u242-b08-jre
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-11.0.18+10-jre
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Mac-launcher.sh
+++ b/launcher-scripts/Mac-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=${0:A:h}
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk8u242-b08-jre/Contents/Home
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-11.0.18+10-jre/Contents/Home
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,7 +1,7 @@
 @echo off
 set OLD_JAVA_HOME="%JAVA_HOME%"
 set "BAT_DIRECTORY=%~dp0"
-set "JAVA_HOME=%BAT_DIRECTORY%jdk8u242-b08-jre"
+set "JAVA_HOME=%BAT_DIRECTORY%jdk-11.0.18+10-jre"
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
 set JAVA_HOME="%OLD_JAVA_HOME%"
 set OLD_JAVA_HOME=""


### PR DESCRIPTION
Since 2023.1,  Jar `adminconsole`  created from OEQ requires Java 11.
So we must update the launcher to bundle JRE for Java 11 as well. 

The OpenJDK distribution is Temurin as it's the chose distribution in OEQ.


Locally tested on Windows and Linux.

![image](https://user-images.githubusercontent.com/47203811/217145968-3a004524-8bec-49f0-998e-7aa51d62a8bd.png)


![image](https://user-images.githubusercontent.com/47203811/217146090-05641880-0108-4ac3-acbc-b2b090ca4efd.png)

