### PR TITLE
build(GHA): use Temurin JDK 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: openEQUELLA Admin Console Launcer CI
+name: openEQUELLA Admin Console Launcher CI
 
 on:
   push:
@@ -30,11 +30,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: adopt
-          java-version: 8
+          distribution: temurin
+          java-version: 11
 
       - name: Build with Gradle
         run: ./gradlew build
@@ -58,4 +58,3 @@ jobs:
           files: build/distributions/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Considering we package Temurin JDK 11, it makes sense to also build with it.