### PR TITLE
Feat/upgrade java to 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="temurin-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ unable to find valid certification path to requested target
 
 This is because the Java Keystore used by the admin console package does not recognize the Root CA certificate used to sign openEQUELLA's SSL certificate.
 
-The admin-console-package uses its own copy of the JRE, in the `jdk-11.0.18+10-jre` folder. 
-The keystore we need to update is within this folder, at the path `jdk-11.0.18+10-jre/lib/security/cacerts`.
+The admin-console-package uses its own copy of the JRE, in the `jdk-21.0.1+12-jre` folder. 
+The keystore we need to update is within this folder, at the path `jdk-21.0.1+12-jre/lib/security/cacerts`.
 
 The bundled JRE comes with a command line tool which you can use for updating these keystores, called `keytool`. 
-This should work in Mac, Linux and Windows. It is stored in `jdk-11.0.18+10-jre/bin`.
+This should work in Mac, Linux and Windows. It is stored in `jdk-21.0.1+12-jre/bin`.
 
 **NOTE:**
 
@@ -72,7 +72,7 @@ You will need a copy of the Root CA certificate used to sign your SSL certificat
 in which case you should use whatever it was set to.
 
 ```
-keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk-11.0.18+10-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
+keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk-21.0.1+12-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
 ```
 
 The command will display the certificate and prompt the user to `Trust this certificate? [no]:`. Type `yes` and hit Enter.

--- a/build.gradle
+++ b/build.gradle
@@ -54,20 +54,20 @@ final launcherScripts = [
 class JreProperties {
     String hash
     String fileName
-    String getDownloadUrl() {"https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.18%2B10/${fileName}"}
+    String getDownloadUrl() {"https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/${fileName}"}
     File getJre() {new File("build/jre-downloads/${fileName}")}
 }
 
 final jreProperties = [
     windows: new JreProperties(
-            hash: 'dea0fe7fd5fc52cf5e1d3db08846b6a26238cfcc36d5527d1da6e3cb059071b3',
-            fileName: 'OpenJDK11U-jre_x64_windows_hotspot_11.0.18_10.zip'),
+            hash: '38bb68f9db9c85a63496570c53a1bcbac18c808677595d7e939d2f5b38e9a7aa',
+            fileName: 'OpenJDK21U-jre_x64_windows_hotspot_21.0.1_12.zip'),
     linux: new JreProperties(
-            hash: '0e7b196ef8603ac3d38caaf7768b7b0a3c613d60e15a6511bcfb2c894b609e99',
-            fileName: 'OpenJDK11U-jre_x64_linux_hotspot_11.0.18_10.tar.gz'),
+            hash: '277f4084bee875f127a978253cfbaad09c08df597feaf5ccc82d2206962279a3',
+            fileName: 'OpenJDK21U-jre_x64_linux_hotspot_21.0.1_12.tar.gz'),
     mac: new JreProperties(
-            hash: '7c73b1a731fc840f2ecb5633906d687bfee4346a8191d3cb1c4370168b16351f',
-            fileName: 'OpenJDK11U-jre_x64_mac_hotspot_11.0.18_10.tar.gz')
+            hash: 'c21a2648ec21bc4701acfb6b7a1fd90aca001db1efb8454e2980d4c8dcd9e310',
+            fileName: 'OpenJDK21U-jre_x64_mac_hotspot_21.0.1_12.tar.gz')
 ]
 
 task copyDependencies(type: Copy, description: 'Copy dependencies to /build/libs') {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,9 @@ dependencies {
 
 group = 'org.apereo.openequella.adminconsole'
 version = System.getenv("TRAVIS_TAG") ?: artifactVersion
-mainClassName = 'org.apereo.openequella.adminconsole.launcher.ClientLauncher'
+application {
+    mainClass = 'org.apereo.openequella.adminconsole.launcher.ClientLauncher'
+}
 
 license {
     strictCheck
@@ -37,14 +39,15 @@ jar {
     manifest {
         attributes('Implementation-Title': project.name,
                 'Implementation-Version': project.version,
-                'Main-Class': mainClassName,
+                'Main-Class': application.mainClass,
                 "Class-Path": configurations.runtimeClasspath.files.collect { it.getName() }.join(' '))
     }
 }
 
-final jreDownloadDir = file("$buildDir/jre-downloads")
+final buildDirectory = getLayout().getBuildDirectory()
+final jreDownloadDir = buildDirectory.dir("jre-downloads").get().asFile
 final jreExtractDir = {sys -> "${jreDownloadDir.absolutePath}/jre/${sys}"}
-final jarDir = "${buildDir}/libs"
+final jarDir = buildDirectory.dir("libs").get().asFile
 final launcherScripts = [
     windows: 'Windows-launcher.bat',
     linux: 'Linux-launcher.sh',
@@ -71,9 +74,10 @@ final jreProperties = [
 ]
 
 task copyDependencies(type: Copy, description: 'Copy dependencies to /build/libs') {
-    from configurations.default
+    from configurations.runtimeClasspath
     into(jarDir)
 }
+copyDependencies.mustRunAfter(startScripts)
 
 task downloadJre(description: 'Download OpenJRE of Linux, Windows and Mac') {
     doFirst {
@@ -85,7 +89,7 @@ task downloadJre(description: 'Download OpenJRE of Linux, Windows and Mac') {
                 .collect {String sys, JreProperties props ->
             Thread.start {
                 println("Start downloading OpenJRE for ${sys}...")
-                new URL(props.downloadUrl as String).withInputStream {
+                new URI(props.downloadUrl as String).toURL().withInputStream {
                     props.jre.newOutputStream() << it
                 }
             }
@@ -150,8 +154,8 @@ distributions {
         "${sys}Packages" {
             distributionBaseName = "admin-console-package-for-${sys}"
             contents {
-                from("${buildDir}") {
-                    include "libs/*"
+                into("libs") {
+                    from {jarDir}
                 }
                 from {file(jreExtractDir(sys))}
                 from {file(scriptFileDir)}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/launcher-scripts/Linux-launcher.sh
+++ b/launcher-scripts/Linux-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=`readlink -f "$(dirname "$0")"`
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-11.0.18+10-jre
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-21.0.1+12-jre
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Mac-launcher.sh
+++ b/launcher-scripts/Mac-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=${0:A:h}
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-11.0.18+10-jre/Contents/Home
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-21.0.1+12-jre/Contents/Home
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,7 +1,7 @@
 @echo off
 set OLD_JAVA_HOME="%JAVA_HOME%"
 set "BAT_DIRECTORY=%~dp0"
-set "JAVA_HOME=%BAT_DIRECTORY%jdk-11.0.18+10-jre"
+set "JAVA_HOME=%BAT_DIRECTORY%jdk-21.0.1+12-jre"
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
 set JAVA_HOME="%OLD_JAVA_HOME%"
 set OLD_JAVA_HOME=""

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'admin-console-launcher'
-include 'launcher'

--- a/src/main/java/org/apereo/openequella/adminconsole/service/JarService.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/service/JarService.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -84,7 +85,7 @@ public class JarService {
 			// hit the server to download
 			//final URL url = new URL(baseUrl + "/console.do?jar=" + URLEncoder.encode(jarName + ".jar", "utf-8"));
 			final String strUrl = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "adminconsole.jar";
-			final URL url = new URL(strUrl);
+			final URL url = new URI(strUrl).toURL();
 			HttpURLConnection conn = null;
 			try {
 				conn = (HttpURLConnection) url.openConnection();

--- a/src/main/java/org/apereo/openequella/adminconsole/util/BlindSSLSocketFactory.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/util/BlindSSLSocketFactory.java
@@ -36,7 +36,7 @@ import javax.net.ssl.X509TrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BlindSSLSocketFactory extends SSLSocketFactory {
+public class BlindSSLSocketFactory extends SSLSocketFactory implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(BlindSSLSocketFactory.class);
   private static SSLSocketFactory originalFactory;
   private static HostnameVerifier originalHostnameVerifier;
@@ -102,17 +102,6 @@ public class BlindSSLSocketFactory extends SSLSocketFactory {
   }
 
   @Override
-  protected void finalize() throws Throwable {
-    if (originalFactory != null) {
-      HttpsURLConnection.setDefaultSSLSocketFactory(originalFactory);
-    }
-    if (originalHostnameVerifier != null) {
-      HttpsURLConnection.setDefaultHostnameVerifier(originalHostnameVerifier);
-    }
-    super.finalize();
-  }
-
-  @Override
   public Socket createSocket(String arg0, int arg1) throws IOException {
     return blindFactory.createSocket(arg0, arg1);
   }
@@ -146,5 +135,15 @@ public class BlindSSLSocketFactory extends SSLSocketFactory {
   @Override
   public String[] getSupportedCipherSuites() {
     return blindFactory.getSupportedCipherSuites();
+  }
+
+  @Override
+  public void close() {
+    if (originalFactory != null) {
+      HttpsURLConnection.setDefaultSSLSocketFactory(originalFactory);
+    }
+    if (originalHostnameVerifier != null) {
+      HttpsURLConnection.setDefaultHostnameVerifier(originalHostnameVerifier);
+    }
   }
 }


### PR DESCRIPTION
This PR adds the support for migrating to Java 21, including:

1. Upgrade the bundled Java to v21;
2. Update CI to use Java 21;
3. Update source code and Gradle build configuration for Java 21;