### PR TITLE
fix: open package java.util for all the unnamed modules

### DIFF
--- a/src/main/java/org/apereo/openequella/adminconsole/launcher/ClientLauncher.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/launcher/ClientLauncher.java
@@ -219,8 +219,14 @@ public class ClientLauncher extends JFrame implements ActionListener, WindowList
           jarService.ensureBinJars(jarName);
           loadingDialog.setVisible(false);
 
-          jarService.executeJar(jarName, "com.tle.admin.boot.Bootstrap", "-Djnlp.ENDPOINT=" + url,
-              "-Dplugin.cache.dir=" + StorageService.getCacheFolder(uuid, "cache"), "-DSERVER_NAME=" + serverProfile.getName());
+          jarService.executeJar(
+                  jarName,
+                  "com.tle.admin.boot.Bootstrap",
+                  "-Djnlp.ENDPOINT=" + url,
+                  "-Dplugin.cache.dir=" + StorageService.getCacheFolder(uuid, "cache"),
+                  "-DSERVER_NAME=" + serverProfile.getName(),
+                  "--add-opens=java.base/java.util=ALL-UNNAMED"
+          );
 
           ClientLauncher.this.setVisible(true);
         } catch (Throwable t) {


### PR DESCRIPTION
The testing work for migrating Java to 21 on OEQ side has identified an issue where certain Collections cannot be opened properly in the Admin Console. This is because package `java.util` is not accessible for some unnamed modules.

To fix this, we need to add  `add-opens` to the JVM Option list.


Before: 

![image](https://github.com/openequella/openEQUELLA-admin-console-package/assets/47203811/d5511269-643a-49af-88a0-7d89070b31aa)


After:

![image](https://github.com/openequella/openEQUELLA-admin-console-package/assets/47203811/232a6e59-80da-4f52-8e04-082584a15e2c)
