### PR TITLE
OEQ-2740 - build: update jdk to 21.0.9+10

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ unable to find valid certification path to requested target
 
 This is because the Java Keystore used by the admin console package does not recognize the Root CA certificate used to sign openEQUELLA's SSL certificate.
 
-The admin-console-package uses its own copy of the JRE, in the `jdk-21.0.1+12-jre` folder. 
-The keystore we need to update is within this folder, at the path `jdk-21.0.1+12-jre/lib/security/cacerts`.
+The admin-console-package uses its own copy of the JRE, in the `jdk-21.0.9+10-jre` folder. 
+The keystore we need to update is within this folder, at the path `jdk-21.0.9+10-jre/lib/security/cacerts`.
 
 The bundled JRE comes with a command line tool which you can use for updating these keystores, called `keytool`. 
-This should work in Mac, Linux and Windows. It is stored in `jdk-21.0.1+12-jre/bin`.
+This should work in Mac, Linux and Windows. It is stored in `jdk-21.0.9+10-jre/bin`.
 
 **NOTE:**
 
@@ -72,7 +72,7 @@ You will need a copy of the Root CA certificate used to sign your SSL certificat
 in which case you should use whatever it was set to.
 
 ```
-keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk-21.0.1+12-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
+keytool -import -trustcacerts -keystore path/to/adminconsolepackage/jdk-21.0.9+10-jre/lib/security/cacerts -storepass changeit -alias giveYourCertANameHere -file path/to/rootCA.pem
 ```
 
 The command will display the certificate and prompt the user to `Trust this certificate? [no]:`. Type `yes` and hit Enter.

--- a/build.gradle
+++ b/build.gradle
@@ -57,20 +57,20 @@ final launcherScripts = [
 class JreProperties {
     String hash
     String fileName
-    String getDownloadUrl() {"https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/${fileName}"}
+    String getDownloadUrl() {"https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/${fileName}"}
     File getJre() {new File("build/jre-downloads/${fileName}")}
 }
 
 final jreProperties = [
     windows: new JreProperties(
-            hash: '38bb68f9db9c85a63496570c53a1bcbac18c808677595d7e939d2f5b38e9a7aa',
-            fileName: 'OpenJDK21U-jre_x64_windows_hotspot_21.0.1_12.zip'),
+            hash: '39c5e23f3ce4d420663afba8ffde28034b72e2b3e240943dc2321bc1f912eef9',
+            fileName: 'OpenJDK21U-jre_x64_windows_hotspot_21.0.9_10.zip'),
     linux: new JreProperties(
-            hash: '277f4084bee875f127a978253cfbaad09c08df597feaf5ccc82d2206962279a3',
-            fileName: 'OpenJDK21U-jre_x64_linux_hotspot_21.0.1_12.tar.gz'),
+            hash: 'aeab55d064a1a27a3744b0880b9b414077b4ed2b1790817eea3df60aec946431',
+            fileName: 'OpenJDK21U-jre_x64_linux_hotspot_21.0.9_10.tar.gz'),
     mac: new JreProperties(
-            hash: 'c21a2648ec21bc4701acfb6b7a1fd90aca001db1efb8454e2980d4c8dcd9e310',
-            fileName: 'OpenJDK21U-jre_x64_mac_hotspot_21.0.1_12.tar.gz')
+            hash: '945abc49249f1e89a2a6a008d70d63dc42b25bbe5e1711ff97aeec70063008d2',
+            fileName: 'OpenJDK21U-jre_x64_mac_hotspot_21.0.9_10.tar.gz')
 ]
 
 task copyDependencies(type: Copy, description: 'Copy dependencies to /build/libs') {

--- a/launcher-scripts/Linux-launcher.sh
+++ b/launcher-scripts/Linux-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=`readlink -f "$(dirname "$0")"`
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-21.0.1+12-jre
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-21.0.9+10-jre
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Mac-launcher.sh
+++ b/launcher-scripts/Mac-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 OLD_JAVA_HOME=$JAVA_HOME
 SCRIPT_DIRECTORY=${0:A:h}
-export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-21.0.1+12-jre/Contents/Home
+export JAVA_HOME=$SCRIPT_DIRECTORY/jdk-21.0.9+10-jre/Contents/Home
 "$JAVA_HOME/bin/java" -DLAUNCHER_JAVA_PATH="$JAVA_HOME/bin/java" -jar "$SCRIPT_DIRECTORY/libs/admin.jar"
 export JAVA_HOME=$OLD_JAVA_HOME

--- a/launcher-scripts/Windows-launcher.bat
+++ b/launcher-scripts/Windows-launcher.bat
@@ -1,7 +1,7 @@
 @echo off
 set OLD_JAVA_HOME="%JAVA_HOME%"
 set "BAT_DIRECTORY=%~dp0"
-set "JAVA_HOME=%BAT_DIRECTORY%jdk-21.0.1+12-jre"
+set "JAVA_HOME=%BAT_DIRECTORY%jdk-21.0.9+10-jre"
 start "Admin console launcher" /D "%BAT_DIRECTORY%\libs" "%JAVA_HOME%\bin\javaw" -DLAUNCHER_JAVA_PATH="%JAVA_HOME%\bin\java" -jar admin.jar
 set JAVA_HOME="%OLD_JAVA_HOME%"
 set OLD_JAVA_HOME=""


### PR DESCRIPTION
This MR updates the embedded JDK version to the latest build [21.0.9+10](https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.9%2B10).

Tested with Linux:
<img width="1684" height="581" alt="image" src="https://github.com/user-attachments/assets/22fb23e6-9582-404b-acfc-1caa335a1870" />

Tested with Windows:
<img width="1114" height="632" alt="image" src="https://github.com/user-attachments/assets/2ccae3f1-48a4-4997-baa4-c875a4b21a0c" />