### PR TITLE
OEQ-2741 - chore: update NOTICE.md and README.md

### DIFF
--- a/DEPENDENCY_LICENSES.md
+++ b/DEPENDENCY_LICENSES.md
@@ -1,0 +1,71 @@
+
+# Dependency Licenses
+## Dependency License Report
+_2026-02-19 14:22:29 AEDT_
+## Apache License, Version 2.0
+
+**1** **Group:** `com.fasterxml.jackson` **Name:** `jackson-bom` **Version:** `2.21.0` 
+> - **POM Project URL**: [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+**2** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.21.0` 
+> - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-core-2.21.0.jar/META-INF/LICENSE](jackson-core-2.21.0.jar/META-INF/LICENSE) 
+    - [jackson-core-2.21.0.jar/META-INF/NOTICE](jackson-core-2.21.0.jar/META-INF/NOTICE)
+
+**3** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.21.0` 
+> - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-databind-2.21.0.jar/META-INF/LICENSE](jackson-databind-2.21.0.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.21.0.jar/META-INF/NOTICE](jackson-databind-2.21.0.jar/META-INF/NOTICE)
+
+## MIT
+
+**4** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.17` 
+> - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
+> - **POM License**: MIT - [https://opensource.org/license/mit](https://opensource.org/license/mit)
+> - **Embedded license files**: [slf4j-api-2.0.17.jar/META-INF/LICENSE.txt](slf4j-api-2.0.17.jar/META-INF/LICENSE.txt)
+
+**5** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `2.0.17` 
+> - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
+> - **POM License**: MIT - [https://opensource.org/license/mit](https://opensource.org/license/mit)
+> - **Embedded license files**: [slf4j-simple-2.0.17.jar/META-INF/LICENSE.txt](slf4j-simple-2.0.17.jar/META-INF/LICENSE.txt)
+
+## The Apache Software License, Version 2.0
+
+**6** **Group:** `com.fasterxml.jackson` **Name:** `jackson-bom` **Version:** `2.21.0` 
+> - **POM Project URL**: [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+**7** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.21` 
+> - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-annotations-2.21.jar/META-INF/LICENSE](jackson-annotations-2.21.jar/META-INF/LICENSE) 
+    - [jackson-annotations-2.21.jar/META-INF/NOTICE](jackson-annotations-2.21.jar/META-INF/NOTICE)
+
+**8** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.21.0` 
+> - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-core-2.21.0.jar/META-INF/LICENSE](jackson-core-2.21.0.jar/META-INF/LICENSE) 
+    - [jackson-core-2.21.0.jar/META-INF/NOTICE](jackson-core-2.21.0.jar/META-INF/NOTICE)
+
+**9** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.21.0` 
+> - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-databind-2.21.0.jar/META-INF/LICENSE](jackson-databind-2.21.0.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.21.0.jar/META-INF/NOTICE](jackson-databind-2.21.0.jar/META-INF/NOTICE)
+
+**10** **Group:** `org.jasypt` **Name:** `jasypt` **Version:** `1.9.3` 
+> - **POM Project URL**: [http://www.jasypt.org](http://www.jasypt.org)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jasypt-1.9.3.jar/META-INF/LICENSE.txt](jasypt-1.9.3.jar/META-INF/LICENSE.txt) 
+    - [jasypt-1.9.3.jar/META-INF/NOTICE.txt](jasypt-1.9.3.jar/META-INF/NOTICE.txt)
+
+

--- a/DEPENDENCY_LICENSES.md
+++ b/DEPENDENCY_LICENSES.md
@@ -1,71 +1,50 @@
 
 # Dependency Licenses
 ## Dependency License Report
-_2026-02-19 14:22:29 AEDT_
+_2026-02-20 10:49:41 AEDT_
 ## Apache License, Version 2.0
 
 **1** **Group:** `com.fasterxml.jackson` **Name:** `jackson-bom` **Version:** `2.21.0` 
 > - **POM Project URL**: [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**2** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.21.0` 
-> - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-core-2.21.0.jar/META-INF/LICENSE](jackson-core-2.21.0.jar/META-INF/LICENSE) 
-    - [jackson-core-2.21.0.jar/META-INF/NOTICE](jackson-core-2.21.0.jar/META-INF/NOTICE)
-
-**3** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.21.0` 
+**2** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.21` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-databind-2.21.0.jar/META-INF/LICENSE](jackson-databind-2.21.0.jar/META-INF/LICENSE) 
-    - [jackson-databind-2.21.0.jar/META-INF/NOTICE](jackson-databind-2.21.0.jar/META-INF/NOTICE)
-
-## MIT
-
-**4** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.17` 
-> - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
-> - **POM License**: MIT - [https://opensource.org/license/mit](https://opensource.org/license/mit)
-> - **Embedded license files**: [slf4j-api-2.0.17.jar/META-INF/LICENSE.txt](slf4j-api-2.0.17.jar/META-INF/LICENSE.txt)
-
-**5** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `2.0.17` 
-> - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
-> - **POM License**: MIT - [https://opensource.org/license/mit](https://opensource.org/license/mit)
-> - **Embedded license files**: [slf4j-simple-2.0.17.jar/META-INF/LICENSE.txt](slf4j-simple-2.0.17.jar/META-INF/LICENSE.txt)
-
-## The Apache Software License, Version 2.0
-
-**6** **Group:** `com.fasterxml.jackson` **Name:** `jackson-bom` **Version:** `2.21.0` 
-> - **POM Project URL**: [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-**7** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.21` 
-> - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [jackson-annotations-2.21.jar/META-INF/LICENSE](jackson-annotations-2.21.jar/META-INF/LICENSE) 
     - [jackson-annotations-2.21.jar/META-INF/NOTICE](jackson-annotations-2.21.jar/META-INF/NOTICE)
 
-**8** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.21.0` 
+**3** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.21.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [jackson-core-2.21.0.jar/META-INF/LICENSE](jackson-core-2.21.0.jar/META-INF/LICENSE) 
     - [jackson-core-2.21.0.jar/META-INF/NOTICE](jackson-core-2.21.0.jar/META-INF/NOTICE)
 
-**9** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.21.0` 
+**4** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.21.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [jackson-databind-2.21.0.jar/META-INF/LICENSE](jackson-databind-2.21.0.jar/META-INF/LICENSE) 
     - [jackson-databind-2.21.0.jar/META-INF/NOTICE](jackson-databind-2.21.0.jar/META-INF/NOTICE)
 
-**10** **Group:** `org.jasypt` **Name:** `jasypt` **Version:** `1.9.3` 
+**5** **Group:** `org.jasypt` **Name:** `jasypt` **Version:** `1.9.3` 
 > - **POM Project URL**: [http://www.jasypt.org](http://www.jasypt.org)
-> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [jasypt-1.9.3.jar/META-INF/LICENSE.txt](jasypt-1.9.3.jar/META-INF/LICENSE.txt) 
     - [jasypt-1.9.3.jar/META-INF/NOTICE.txt](jasypt-1.9.3.jar/META-INF/NOTICE.txt)
+
+## MIT License
+
+**6** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.17` 
+> - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+> - **Embedded license files**: [slf4j-api-2.0.17.jar/META-INF/LICENSE.txt](slf4j-api-2.0.17.jar/META-INF/LICENSE.txt)
+
+**7** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `2.0.17` 
+> - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+> - **Embedded license files**: [slf4j-simple-2.0.17.jar/META-INF/LICENSE.txt](slf4j-simple-2.0.17.jar/META-INF/LICENSE.txt)
 
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-Copyright <2019>, The Apereo Foundation
+Copyright <2026>, The Apereo Foundation
 
 This project includes software developed by The Apereo Foundation.
 http://www.apereo.org/
@@ -15,15 +15,6 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 
-# admin-console-package-licenses
+---
 
-| Category              | License                                                                   | Dependency                                           | Notes                   |
-| --------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------- | ----------------------- |
-| Apache                | [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)                 | nebula.lint # 16.26.0                                  | <notextile></notextile> |
-| Apache                | [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)                 | com.github.hierynomus.license # 0.15.0               | <notextile></notextile> |
-| Apache                | [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)                 | com.google.guava:guava # 27.0.1-jre                  | <notextile></notextile> |
-| Apache                | [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)                 | com.fasterxml.jackson.core:jackson-databind # 2.12.3  | <notextile></notextile> |
-| Apache                | [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)                 | org.jasypt:jasypt # 1.9.3                            | <notextile></notextile> |
-| Eclipse Public License| [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html )  | junit:junit # 4.13.2                                   | <notextile></notextile> |
-| MIT License           | [MIT License](http://www.opensource.org/licenses/mit-license.php)         | org.slf4j:slf4j-api # 1.7.31                         | <notextile></notextile> |
-| MIT License           | [MIT License](http://www.opensource.org/licenses/mit-license.php)         | org.slf4j:slf4j-simple # 1.7.31                       | <notextile></notextile> |
+Additional third-party license information is available in `DEPENDENCY_LICENSES.md`.

--- a/README.md
+++ b/README.md
@@ -13,20 +13,23 @@ For development, you can run the app via:
 ~$ ./gradlew run --console=verbose
 ```
 
-## Apereo Header validation
-The gradle build includes a task which will check that each source file in the common and configurator projects has an Apereo 
-license notice at the top of the file. This license is stored in `LICENSE` in the root of this repository.
-In order to apply the headers, run:
+## Apereo License Header Validation
+The Gradle build uses Checkstyle to validate that each Java source file has an Apereo 
+license notice at the top of the file. The license header template is stored in `config/checkstyle/license.header`.
+
+To check that the headers are present, run:
 
 ```
--$ ./gradlew licenseFormat
+~$ ./gradlew checkstyleMain checkstyleTest
 ```
- In order to check that the headers have been applied, run:
- 
- ```
- -$ ./gradlew license
- ```
-NOTE: The license check is executed as part of the standard `build` target.
+
+Or simply run the standard check task:
+
+```
+~$ ./gradlew check
+```
+
+**NOTE:** The license header check is executed as part of the standard `build` target. If headers are missing, you will need to manually add them to the affected files using the template in `config/checkstyle/license.header`.
 
 ## Creating packages for Linux, Windows and Mac
 The gradle build includes a task which creates three packages by bundling OpenJDK, all dependencies of this project and a system-specific launcher script.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Or simply run the standard check task:
 
 **NOTE:** The license header check is executed as part of the standard `build` target. If headers are missing, you will need to manually add them to the affected files using the template in `config/checkstyle/license.header`.
 
+## Dependency license report
+
+A detailed list of third-party dependency licenses is generated into `DEPENDENCY_LICENSES.md`.
+
+To regenerate:
+`./gradlew generateLicenseReport`
+
 ## Creating packages for Linux, Windows and Mac
 The gradle build includes a task which creates three packages by bundling OpenJDK, all dependencies of this project and a system-specific launcher script.
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ licenseReport {
         new InventoryMarkdownReportRenderer("DEPENDENCY_LICENSES.md", "Dependency Licenses")
     ]
     // Normalize the license names to make them more readable and consistent in the report, and remove duplicates.
-    // For example, "The Apache Software License, Version 2.0" and "Apache License 2.0" will both be normalized to "Apache License 2.0".
+    // For example, "The Apache Software License, Version 2.0" and "Apache License, Version 2.0" are both normalized to "Apache License, Version 2.0".
     filters = [ new LicenseBundleNormalizer() ]
     outputDir = rootDir.absolutePath
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,15 @@ checkstyle {
 }
 
 import com.github.jk1.license.render.InventoryMarkdownReportRenderer
+import com.github.jk1.license.filter.LicenseBundleNormalizer
 // Generate a markdown report for dependencies and their licenses, and put it in the root directory of the project.
 licenseReport {
     renderers = [
         new InventoryMarkdownReportRenderer("DEPENDENCY_LICENSES.md", "Dependency Licenses")
     ]
+    // Normalize the license names to make them more readable and consistent in the report, and remove duplicates.
+    // For example, "The Apache Software License, Version 2.0" and "Apache License 2.0" will both be normalized to "Apache License 2.0".
+    filters = [ new LicenseBundleNormalizer() ]
     outputDir = rootDir.absolutePath
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'application'
     id 'base'
     id 'checkstyle'
+    id 'com.github.jk1.dependency-license-report' version '3.1.1'
 }
 
 repositories {
@@ -30,6 +31,15 @@ checkstyle {
     configProperties = [
         'config.folder': file("${projectDir}/config/checkstyle").absolutePath
     ]
+}
+
+import com.github.jk1.license.render.InventoryMarkdownReportRenderer
+// Generate a markdown report for dependencies and their licenses, and put it in the root directory of the project.
+licenseReport {
+    renderers = [
+        new InventoryMarkdownReportRenderer("DEPENDENCY_LICENSES.md", "Dependency Licenses")
+    ]
+    outputDir = rootDir.absolutePath
 }
 
 jar {


### PR DESCRIPTION
1. Add a plugin (https://github.com/jk1/Gradle-License-Report) and use it to generate dependency license info. Based on the suggestions from https://github.com/openequella/openEQUELLA-admin-console-package/issues/64
2. Update the year for copyright.
3. Update NOTICE.md.
4. Update README.md.

Dependency Licenses Report:

<img width="1255" height="722" alt="image" src="https://github.com/user-attachments/assets/17a293fe-00c2-4c1f-bb29-e857dfacd3d3" />
<img width="1241" height="1118" alt="image" src="https://github.com/user-attachments/assets/0248b45f-704c-4e73-bf79-fb8d8658cc35" />
